### PR TITLE
User events and jobs through leadership roles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,12 +25,12 @@ class User < ActiveRecord::Base
     ROLES.index(base_role.to_s) <= ROLES.index(role)
   end
 
-  def unique_events
-    events.uniq
+  def all_events
+    (event_leads + events).uniq
   end
 
-  def unique_teams
-    teams.uniq
+  def all_teams
+    (team_leads + teams).uniq
   end
 
   def send_information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,9 +7,10 @@ class User < ActiveRecord::Base
   validates_presence_of :role
 
   has_many :jobs, :dependent => :nullify
-
-  has_many :events, through: :jobs, source: :workable, source_type: 'Event'
-  has_many :teams, through: :jobs, source: :workable, source_type: 'Team'
+  has_many :events, through: :jobs, source: :workable, source_type: 'Event', uniq: true
+  has_many :teams, through: :jobs, source: :workable, source_type: 'Team', uniq: true
+  has_many :event_leads, through: :leadership_roles, source: :leadable, source_type: 'Event'
+  has_many :team_leads, through: :leadership_roles, source: :leadable, source_type: 'Team'
   has_many :leadership_roles
   has_many :comments
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
 
 <div class='user-jobs'>
   <h2 class='section-header'><%= @user.first_name %>'s Jobs:</h2>
-  <% @user.unique_events.each do |event| %>
+  <% @user.events.each do |event| %>
     <%= render event %>
     <% event.jobs.each do |job| %>
       <% if job.owned_by?(@user) %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,21 +13,27 @@ describe User do
   it { should have_many(:comments)}
   it { should have_many(:teams).through(:jobs) }
   it { should have_many(:leadership_roles) }
+  it { should have_many(:event_leads) }
+  it { should have_many(:team_leads) }
 
-  it "tells you each unique event it is signed up for" do
-    user = FactoryGirl.create(:volunteer)
-    event = FactoryGirl.create(:event)
-    job1 = FactoryGirl.create(:job, :user_id => user.id, workable_id: event.id, workable_type: 'Event')
-    job2 = FactoryGirl.create(:job, :user_id => user.id, workable_id: event.id, workable_type: 'Event')
-    user.unique_events.should eq [event]
+  describe '#events' do
+    it "should only return unique events" do
+      user = FactoryGirl.create(:volunteer)
+      event = FactoryGirl.create(:event)
+      job1 = FactoryGirl.create(:job, :user_id => user.id, workable_id: event.id, workable_type: 'Event')
+      job2 = FactoryGirl.create(:job, :user_id => user.id, workable_id: event.id, workable_type: 'Event')
+      user.events.should eq [event]
+    end
   end
 
-  it "tells you each unique team it is signed up for" do
-    user = FactoryGirl.create(:volunteer)
-    team = FactoryGirl.create(:team)
-    job1 = FactoryGirl.create(:job, :user_id => user.id, workable_id: team.id, workable_type: 'Team')
-    job2 = FactoryGirl.create(:job, :user_id => user.id, workable_id: team.id, workable_type: 'Team')
-    user.unique_teams.should eq [team]
+  describe '#teams' do
+    it "tells you each unique team it is signed up for" do
+      user = FactoryGirl.create(:volunteer)
+      team = FactoryGirl.create(:team)
+      job1 = FactoryGirl.create(:job, :user_id => user.id, workable_id: team.id, workable_type: 'Team')
+      job2 = FactoryGirl.create(:job, :user_id => user.id, workable_id: team.id, workable_type: 'Team')
+      user.teams.should eq [team]
+    end
   end
 
   it "sends an e-mail" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,25 +16,63 @@ describe User do
   it { should have_many(:event_leads) }
   it { should have_many(:team_leads) }
 
-  describe '#events' do
-    it "should only return unique events" do
-      user = FactoryGirl.create(:volunteer)
-      event = FactoryGirl.create(:event)
-      job1 = FactoryGirl.create(:job, :user_id => user.id, workable_id: event.id, workable_type: 'Event')
-      job2 = FactoryGirl.create(:job, :user_id => user.id, workable_id: event.id, workable_type: 'Event')
-      user.events.should eq [event]
+    describe '#events' do
+      it "should only return unique events" do
+        user = FactoryGirl.create(:volunteer)
+        event = FactoryGirl.create(:event)
+        job1 = FactoryGirl.create(:job, :user_id => user.id, workable_id: event.id, workable_type: 'Event')
+        job2 = FactoryGirl.create(:job, :user_id => user.id, workable_id: event.id, workable_type: 'Event')
+        user.events.should eq [event]
+      end
     end
-  end
 
-  describe '#teams' do
-    it "tells you each unique team it is signed up for" do
-      user = FactoryGirl.create(:volunteer)
-      team = FactoryGirl.create(:team)
-      job1 = FactoryGirl.create(:job, :user_id => user.id, workable_id: team.id, workable_type: 'Team')
-      job2 = FactoryGirl.create(:job, :user_id => user.id, workable_id: team.id, workable_type: 'Team')
-      user.teams.should eq [team]
+    describe '#all_events' do
+      it "should return all the events associated with the user through jobs and leadership roles" do
+        user = FactoryGirl.create(:volunteer)
+        event1 = FactoryGirl.create(:event)
+        event2 = FactoryGirl.create(:event)
+        user.leadership_roles << event1.leadership_role
+        user.jobs << FactoryGirl.create(:job, workable_id: event2.id, workable_type: 'Event')
+        user.all_events.should eq [event1, event2]
+      end
+
+      it "should only return unique events" do
+        user = FactoryGirl.create(:volunteer)
+        event = FactoryGirl.create(:event)
+        user.leadership_roles << event.leadership_role
+        user.jobs << FactoryGirl.create(:job, workable_id: event.id, workable_type: 'Event')
+        user.all_events.should eq [event]
+      end
     end
-  end
+
+    describe '#teams' do
+      it "tells you each unique team it is signed up for" do
+        user = FactoryGirl.create(:volunteer)
+        team = FactoryGirl.create(:team)
+        job1 = FactoryGirl.create(:job, :user_id => user.id, workable_id: team.id, workable_type: 'Team')
+        job2 = FactoryGirl.create(:job, :user_id => user.id, workable_id: team.id, workable_type: 'Team')
+        user.teams.should eq [team]
+      end
+
+      it "should only return unique teams" do
+        user = FactoryGirl.create(:volunteer)
+        team = FactoryGirl.create(:team)
+        user.leadership_roles << team.leadership_role
+        user.jobs << FactoryGirl.create(:job, workable_id: team.id, workable_type: 'Team')
+        user.all_teams.should eq [team]
+      end
+    end
+
+    describe '#all_teams' do
+      it "should return all the events associated with the user through jobs and leadership roles" do
+        user = FactoryGirl.create(:volunteer)
+        team1 = FactoryGirl.create(:team)
+        team2 = FactoryGirl.create(:team)
+        user.leadership_roles << team1.leadership_role
+        user.jobs << FactoryGirl.create(:job, workable_id: team2.id, workable_type: 'Team')
+        user.all_teams.should eq [team1, team2]
+      end
+    end
 
   it "sends an e-mail" do
     user = FactoryGirl.create(:volunteer)


### PR DESCRIPTION
A couple of major changes:
- Added associations called `event_leads` and `team_leads` to the User model that will retrieve all the events and teams the user is leading respectively.
- Added a `uniq: true` option on the has_many associations with events and teams through workable. This allows us to call `user#events` and `user#teams` and get unique results without needing our own methods.
- Also added methods `user#all_events` and `user#all_teams` that will retrieve all the events and teams associated with the user through both jobs and leadership roles (thanks whoever wrote those first has_many associations as it made it easy for me to add this).

Let me know what you think, especially about the `*_leads` associations. Cheers!
