### PR TITLE
Leader commitments

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,6 +21,14 @@ class Event < ActiveRecord::Base
     leadership_role.user
   end
 
+  def jobs_of_user(user)
+    jobs.where(user: user)
+  end
+
+  def teams_of_user(user)
+    teams.where(leadership_role: { user: user }) + teams.where() 
+  end
+
   def self.past
     Event.where("finish < ?", Time.now)
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -26,7 +26,9 @@ class Event < ActiveRecord::Base
   end
 
   def teams_of_user(user)
-    teams.where(leadership_role: { user: user }) + teams.where() 
+    teams.select do |team|
+      team.leadership_role.user == user || team.jobs.any? { |job| job.user == user }
+    end
   end
 
   def self.past

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,9 +1,7 @@
 class Team < ActiveRecord::Base
   validates :name, presence: true
 
-  has_many :jobs, through: :users
   has_many :jobs, :as => :workable
-  has_many :users
   belongs_to :event
   has_one :leadership_role, :as => :leadable, :dependent => :destroy
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -11,6 +11,10 @@ class Team < ActiveRecord::Base
     leadership_role.user
   end
 
+  def jobs_of_user(user)
+    jobs.where(user: user)
+  end
+
 private
 
   def create_leadership_role

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ActiveRecord::Base
   has_many :teams, -> { uniq }, through: :jobs, source: :workable, source_type: 'Team'
   has_many :events_through_teams, -> { uniq }, through: :teams, source: :event
   has_many :event_leads, through: :leadership_roles, source: :leadable, source_type: 'Event'
+  has_many :events_through_team_leads, through: :team_leads, source: :event
   has_many :team_leads, through: :leadership_roles, source: :leadable, source_type: 'Team'
   has_many :leadership_roles, :dependent => :nullify
   has_many :comments
@@ -31,7 +32,7 @@ class User < ActiveRecord::Base
   end
 
   def all_events
-    (events_through_teams.upcoming + event_leads.upcoming + events.upcoming).uniq
+    (events_through_teams.upcoming + events_through_team_leads.upcoming + event_leads.upcoming + events.upcoming).uniq
   end
 
   def all_teams

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ActiveRecord::Base
   has_many :jobs, :dependent => :nullify
   has_many :events, -> { uniq }, through: :jobs, source: :workable, source_type: 'Event'
   has_many :teams, -> { uniq }, through: :jobs, source: :workable, source_type: 'Team'
+  has_many :events_through_teams, -> { uniq }, through: :teams, source: :event
   has_many :event_leads, through: :leadership_roles, source: :leadable, source_type: 'Event'
   has_many :team_leads, through: :leadership_roles, source: :leadable, source_type: 'Team'
   has_many :leadership_roles, :dependent => :nullify
@@ -25,8 +26,12 @@ class User < ActiveRecord::Base
     ROLES.index(base_role.to_s) <= ROLES.index(role)
   end
 
+  def commitment_events
+    all_events.sort
+  end
+
   def all_events
-    (event_leads + events).uniq
+    (events_through_teams.upcoming + event_leads.upcoming + events.upcoming).uniq
   end
 
   def all_teams

--- a/app/views/teams/_team_short.html.erb
+++ b/app/views/teams/_team_short.html.erb
@@ -1,0 +1,6 @@
+<h4><%= team.name %></h4>
+<ul>
+  <% team.jobs_of_user(user).each do |job| %>
+    <li><%= link_to job.name, job %></li>
+  <% end %>
+</ul>

--- a/app/views/users/_commitments.html.erb
+++ b/app/views/users/_commitments.html.erb
@@ -1,8 +1,10 @@
 <% events.each do |event| %>
+  <h2><%= event.name %></h2>
 	<% event.jobs_of_user(user).each do |job| %>
-		<%= render job %>
+		<%= link_to job.name, job %>
 	<% end %>
-	<% event.teams_of_user(user).each do |team| %>
 
+	<% event.teams_of_user(user).each do |team| %>
+    <%= render 'teams/team_short', team: team, user: user %>
 	<% end %>
 <% end %>

--- a/app/views/users/_commitments.html.erb
+++ b/app/views/users/_commitments.html.erb
@@ -1,0 +1,8 @@
+<% events.each do |event| %>
+	<% event.jobs_of_user(user).each do |job| %>
+		<%= render job %>
+	<% end %>
+	<% event.teams_of_user(user).each do |team| %>
+
+	<% end %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,22 +4,9 @@
       <div class="col-md-6">
         <h2 class='section-header well'><%= @user.first_name %>'s Commitments:</h2>
         <div class="job-info well">
-          <% @user.events.each do |event| %>
-            <%= render event %>
-            <% event.jobs.each do |job| %>
-              <% if job.owned_by?(@user) %>
-                <%= render job %>
-              <% end %>
-            <% end %>
-            <% @user.teams.each do |team| %>
-              <%= render "teams/team_info_for_dash", :team => team %>
-              <% team.jobs.each do |job| %>
-                <% if job.owned_by?(@user) %>
-                  <%= render job %>
-                <% end %>
-              <% end %>
-            <% end %>
-          <% end %>
+          
+          <%= render 'commitments', events: @user.commitment_events, user: @user %>
+
         </div> 
       </div>   
       <div class="col-md-6 cities"> 

--- a/spec/features/cities_pages_spec.rb
+++ b/spec/features/cities_pages_spec.rb
@@ -54,7 +54,6 @@ feature "City pages" do
 
       scenario "with valid input" do
         fill_in 'Name', with: 'San Francisco, CA'
-        page.save_screenshot('screenshot.png')
         click_on 'Add'
         page.should have_content 'San Francisco, CA'
       end

--- a/spec/features/users_pages_spec.rb
+++ b/spec/features/users_pages_spec.rb
@@ -209,3 +209,49 @@ feature "user_signed_in?" do
   end
 end
 
+feature "showing commitments" do
+  let(:volunteer) { FactoryGirl.create(:volunteer) }
+  before { sign_in(volunteer) }
+  subject { page }
+
+  context "when leading a event" do
+    let(:event) { FactoryGirl.create(:event) }
+    before do
+      volunteer.leadership_roles << event.leadership_role
+      visit user_path(volunteer)
+    end
+
+    it { should have_content event.name } 
+  end
+
+  context "when leading a team" do
+    let(:team) { FactoryGirl.create(:team) }
+    before do
+      volunteer.leadership_roles << team.leadership_role
+      visit user_path(volunteer)
+    end
+
+    it { should have_content team.event.name } 
+  end
+
+  context "for jobs of events" do
+    let(:job) { FactoryGirl.create(:job) }
+    before do
+      volunteer.jobs << job
+      visit user_path(volunteer)
+    end
+
+    it { should have_content job.workable.name }
+  end
+
+  context "for jobs of teams" do
+    let(:job) { FactoryGirl.create(:team_job) }
+    before do
+      volunteer.jobs << job
+      visit user_path(volunteer)
+    end
+
+    it { should have_content job.workable.event.name }
+  end
+end
+

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -84,16 +84,21 @@ describe Event do
   end
 
   describe '#teams_of_user' do
-    it "returns all the teams of an event for which the user is the leader or has a job" do
-      @user = FactoryGirl.create(:volunteer)
-      @event = FactoryGirl.create(:event)
-      @team_1 = FactoryGirl.create(:team, event: @event)
-      @team_2 = FactoryGirl.create(:team, event: @event)
-      @team_3 = FactoryGirl.create(:team, event: @event)
-      @job = FactoryGirl.create(:job, workable: @team_2)
-      @user.leadership_roles << @team_1.leadership_role
-      @user.jobs << @job
-      @event.teams_of_user(@user).should eq [@team_1, @team_2]
+    let(:volunteer) { FactoryGirl.create(:volunteer) }
+
+    it 'should return all teams that are lead by the passed in user' do
+      team = FactoryGirl.create(:team)
+      event = team.event
+      volunteer.leadership_roles << team.leadership_role
+      event.teams_of_user(volunteer).should eq [team]
+    end
+
+    it 'should return all teams that are lead by the passed in user' do
+      job = FactoryGirl.create(:team_job)
+      team = job.workable
+      event = team.event
+      volunteer.jobs << job
+      event.teams_of_user(volunteer).should eq [team]
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -72,4 +72,28 @@ describe Event do
       event.leader.should eq volunteer
     end
   end
+
+  describe '#jobs_of_user' do
+    it "returns all the jobs of an event that belong to the passed in user" do
+      @user = FactoryGirl.create(:volunteer)
+      @event = FactoryGirl.create(:event)
+      @job_1 = FactoryGirl.create(:job, workable: @event, user: @user)
+      @job_2 = FactoryGirl.create(:job, workable: @event)
+      @event.jobs_of_user(@user).should eq [@job_1]
+    end
+  end
+
+  describe '#teams_of_user' do
+    it "returns all the teams of an event for which the user is the leader or has a job" do
+      @user = FactoryGirl.create(:volunteer)
+      @event = FactoryGirl.create(:event)
+      @team_1 = FactoryGirl.create(:team, event: @event)
+      @team_2 = FactoryGirl.create(:team, event: @event)
+      @team_3 = FactoryGirl.create(:team, event: @event)
+      @job = FactoryGirl.create(:job, workable: @team_2)
+      @user.leadership_roles << @team_1.leadership_role
+      @user.jobs << @job
+      @event.teams_of_user(@user).should eq [@team_1, @team_2]
+    end
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -17,4 +17,15 @@ describe Team do
     team = FactoryGirl.create(:team)
     team.leadership_role.should be_an_instance_of LeadershipRole
   end
+
+  describe '#jobs_of_user' do
+    let(:volunteer) { FactoryGirl.create(:volunteer) }
+    
+    it "returns all the jobs of an team that belong to the passed in user" do
+      job = FactoryGirl.create(:team_job)
+      team = job.workable
+      volunteer.jobs << job
+      team.jobs_of_user(volunteer).should eq [job]
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,7 @@ describe User do
   it { should have_many(:events).through(:jobs) }
   it { should have_many(:comments)}
   it { should have_many(:teams).through(:jobs) }
+  it { should have_many(:events_through_teams).through(:teams) }
   it { should have_many(:leadership_roles).dependent(:nullify) }
   it { should have_many(:event_leads) }
   it { should have_many(:team_leads) }
@@ -95,6 +96,19 @@ describe User do
       pending_user = FactoryGirl.build(:volunteer, :invitation_token => 'sample token')
       pending_user.save(:validate => false)
       User.confirmed.should eq [confirmed_user]
+    end
+  end
+
+  describe "commitment_events" do
+    it "returns all the events in which the user has a commitment" do
+      user = FactoryGirl.create(:volunteer)
+      team_job = FactoryGirl.create(:team_job)
+      team_leadership_role = team_job.workable.leadership_role
+      event_job = FactoryGirl.create(:job)
+      event_leadership_role = FactoryGirl.create(:event).leadership_role
+      user.jobs << [team_job, event_job]
+      user.leadership_roles << [team_leadership_role, event_leadership_role]
+      user.commitment_events.should eq [team_job.workable.event, event_job.workable, event_leadership_role.leadable]
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,16 +99,31 @@ describe User do
     end
   end
 
-  describe "commitment_events" do
-    it "returns all the events in which the user has a commitment" do
-      user = FactoryGirl.create(:volunteer)
-      team_job = FactoryGirl.create(:team_job)
-      team_leadership_role = team_job.workable.leadership_role
-      event_job = FactoryGirl.create(:job)
-      event_leadership_role = FactoryGirl.create(:event).leadership_role
-      user.jobs << [team_job, event_job]
-      user.leadership_roles << [team_leadership_role, event_leadership_role]
-      user.commitment_events.should eq [team_job.workable.event, event_job.workable, event_leadership_role.leadable]
+  describe "#commitment_events" do
+    let(:volunteer) { FactoryGirl.create(:volunteer) }
+
+    it 'should return events you are leading' do
+      event = FactoryGirl.create(:event)
+      volunteer.leadership_roles << event.leadership_role
+      volunteer.commitment_events.should eq [event]
+    end
+
+    it 'should return events you have a job in' do
+      job = FactoryGirl.create(:job)
+      volunteer.jobs << job
+      volunteer.commitment_events.should eq [job.workable]
+    end
+
+    it 'should return events in which you are leading a team' do
+      team = FactoryGirl.create(:team)
+      volunteer.leadership_roles << team.leadership_role
+      volunteer.commitment_events.should eq [team.event]
+    end
+
+    it 'should return events with a team you have a job in' do
+      job = FactoryGirl.create(:team_job)
+      volunteer.jobs << job
+      volunteer.commitment_events.should eq [job.workable.event]
     end
   end
 end


### PR DESCRIPTION
This will add some logic to let us display all of the commitments for a user. Our goal is to display all the events in which a user has a commitment. The challenge was there are four types of commitments a user has that makes that possible.
- User is leading the event
- User is leading a team in the event
- User has a job within the event
- User has a job within a team within the event

I added multiple associations between users and events, directed through those four different paths (maybe could use some refactoring here) in order to pull out all the unique events associated with a user.

I then added logic to events and teams that would allow you to pull out all the jobs/leadership_roles within an event/team that are associated with a passed in user. While this feels a little big hacky, my choice was between this, or logic in the view. I'm definitely open to suggestions on that.
